### PR TITLE
Feature/diagonal line

### DIFF
--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -85,12 +85,33 @@ class Bitmap
       coords_to_fill = build_forwards_coords(x1, y1, x2, y2)
     end
 
+    print coords_to_fill
+    puts coords_to_fill.size
+    puts x1
+    puts x2
+    puts y1
+    puts y2
+
+    raise DiagonalError.new unless is_a_diagonal?(coords_to_fill, x1, x2)
+
     coords_to_fill.each do |coord|
       color_pixel(coord[0], coord[1], color)
     end
   end
 
   private
+
+  def is_a_diagonal?(coords, x1, x2)
+    # This is far from perfect.
+    return false if coords.size == 1
+
+    # Return false if x +- 1 && y += 1 - i.e. no adjacency to the next coord.
+    coords.each_index do |i|
+      break if coords[i+1].nil?
+      puts false if (coords[i+1][0]) != ((coords[i][0] + 1) || (coords[i][0] - 1)) && (coords[i+1][1]) != ((coords[i][1] + 1) || (coords[i][1] - 1))
+    end
+    true
+  end
 
   def valid_size?(width, height)
     (MIN_SIZE..MAX_SIZE).include?(width) && (MIN_SIZE..MAX_SIZE).include?(height)
@@ -120,16 +141,12 @@ class Bitmap
     x1.between?(0, width) && x2.between?(0, width) && y1.between?(0, height) && y2.between?(0, height)
   end
 
-  def is_a_diagonal?(x1, x2, y1, y2)
-    # TODO: Define what coords constitute a valid diagonal.
-    true
-  end
-
   # A backwards diagonal is \
   def backwards_diagonal?(x1, y1, x2, y2)
     x1 < y1 && x2 > y2
   end
 
+  # Builds a set in coords [[5, 0], [4, 1], etc.] for \
   def build_backwards_coords(x1, y1, x2, y2)
     coords = []
 
@@ -145,6 +162,7 @@ class Bitmap
     coords
   end
 
+  # Builds a set in coords [[0, 0], [1, 1], etc.] for /
   def build_forwards_coords(x1, y1, x2, y2)
     coords = []
 

--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -72,7 +72,37 @@ class Bitmap
     end
   end
 
+  # Example: D 1 1 6 6 C
+  # Draw a diagonal segment of colour C from 1,1 to 6,6
+  def diagonal_segment(x1, y1, x2, y2, color)
+    if x2 < x1
+      x1, x2 = x2, x1
+      y1, y2 = y2, y1
+    end
+
+    coords_to_fill = build_coords(x1, y1, x2, y2)
+
+    print coords_to_fill
+
+    coords_to_fill.each do |coord|
+      color_pixel(coord[0], coord[1], color)
+    end
+  end
+
   private
+
+  def build_coords(x1, y1, x2, y2)
+    coords = []
+
+    x1.upto(x2).each { |x| coords << [x] }
+
+    y1.upto(y2).each_with_index do |y, y_index|
+      coords.each_with_index do |el, coords_index|
+        el << y if y_index == coords_index
+      end
+    end
+    coords
+  end
 
   def valid_size?(width, height)
     (MIN_SIZE..MAX_SIZE).include?(width) && (MIN_SIZE..MAX_SIZE).include?(height)

--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -74,15 +74,19 @@ class Bitmap
 
   # Example: D 1 1 6 6 C
   # Draw a diagonal segment of colour C from 1,1 to 6,6
+  # Specify X1 as the left most pixel. I.e. X1 must be smaller than X2.
   def diagonal_segment(x1, y1, x2, y2, color)
-    if x2 < x1
-      x1, x2 = x2, x1
-      y1, y2 = y2, y1
+    # raise InvalidColorError.new(color) unless valid_color?(color)
+    # raise InvalidDiagonalError.new unless valid_diagonal?
+    # raise DiagonalOutOfBoundsError.new unless horizontal_segment_valid?(x1.to_i, x2.to_i, y.to_i)
+
+    #TODO: Raise if the coords are not a valid diagonal.
+
+    if backwards_diagonal?(x1, y1, x2, y2) # i.e \
+      coords_to_fill = build_backwards_coords(x1, y1, x2, y2)
+    else # It is a forward facing diagonal /
+      coords_to_fill = build_forwards_coords(x1, y1, x2, y2)
     end
-
-    coords_to_fill = build_coords(x1, y1, x2, y2)
-
-    print coords_to_fill
 
     coords_to_fill.each do |coord|
       color_pixel(coord[0], coord[1], color)
@@ -91,7 +95,27 @@ class Bitmap
 
   private
 
-  def build_coords(x1, y1, x2, y2)
+  # A backwards diagonal \
+  def backwards_diagonal?(x1, y1, x2, y2)
+    x1 < y1 && x2 > y2
+  end
+
+  def build_backwards_coords(x1, y1, x2, y2)
+    coords = []
+
+    (x1..x2).to_a.reverse.each { |x| coords << [x] }
+
+    y1, y2 = y2, y1
+    (y1..y2).to_a.each_with_index do |y, y_index|
+      coords.each_with_index do |el, coords_index|
+        el << y if y_index == coords_index
+      end
+    end
+
+    coords
+  end
+
+  def build_forwards_coords(x1, y1, x2, y2)
     coords = []
 
     x1.upto(x2).each { |x| coords << [x] }

--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -76,11 +76,8 @@ class Bitmap
   # Draw a diagonal segment of colour C from 1,1 to 6,6
   # Specify X1 as the left most pixel. I.e. X1 must be smaller than X2.
   def diagonal_segment(x1, y1, x2, y2, color)
-    # raise InvalidColorError.new(color) unless valid_color?(color)
-    # raise InvalidDiagonalError.new unless valid_diagonal?
-    # raise DiagonalOutOfBoundsError.new unless horizontal_segment_valid?(x1.to_i, x2.to_i, y.to_i)
-
-    #TODO: Raise if the coords are not a valid diagonal.
+    raise InvalidColorError.new(color) unless valid_color?(color)
+    raise SegmentOutOfBoundsError.new unless diagonal_segment_in_bounds?(x1, y1, x2, y2)
 
     if backwards_diagonal?(x1, y1, x2, y2) # i.e \
       coords_to_fill = build_backwards_coords(x1, y1, x2, y2)
@@ -95,7 +92,40 @@ class Bitmap
 
   private
 
-  # A backwards diagonal \
+  def valid_size?(width, height)
+    (MIN_SIZE..MAX_SIZE).include?(width) && (MIN_SIZE..MAX_SIZE).include?(height)
+  end
+
+  def valid_color?(color)
+    [*('A'..'Z')].include?(color)
+  end
+
+  def pixel_valid?(x, y)
+    x.between?(0, width) && y.between?(0, height)
+  end
+
+  def vertical_segment_valid?(x, y1, y2)
+    (y1..y2).each do |y|
+      return false unless pixel_valid?(x, y)
+    end
+  end
+
+  def horizontal_segment_valid?(x1, x2, y)
+    (x1..x2).each do |x|
+      return false unless pixel_valid?(x, y)
+    end
+  end
+
+  def diagonal_segment_in_bounds?(x1, y1, x2, y2)
+    x1.between?(0, width) && x2.between?(0, width) && y1.between?(0, height) && y2.between?(0, height)
+  end
+
+  def is_a_diagonal?(x1, x2, y1, y2)
+    # TODO: Define what coords constitute a valid diagonal.
+    true
+  end
+
+  # A backwards diagonal is \
   def backwards_diagonal?(x1, y1, x2, y2)
     x1 < y1 && x2 > y2
   end
@@ -126,29 +156,5 @@ class Bitmap
       end
     end
     coords
-  end
-
-  def valid_size?(width, height)
-    (MIN_SIZE..MAX_SIZE).include?(width) && (MIN_SIZE..MAX_SIZE).include?(height)
-  end
-
-  def valid_color?(color)
-    [*('A'..'Z')].include?(color)
-  end
-
-  def pixel_valid?(x, y)
-    x.between?(0, width) && y.between?(0, height)
-  end
-
-  def vertical_segment_valid?(x, y1, y2)
-    (y1..y2).each do |y|
-      return false unless pixel_valid?(x, y)
-    end
-  end
-
-  def horizontal_segment_valid?(x1, x2, y)
-    (x1..x2).each do |x|
-      return false unless pixel_valid?(x, y)
-    end
   end
 end

--- a/lib/bitmap.rb
+++ b/lib/bitmap.rb
@@ -85,13 +85,6 @@ class Bitmap
       coords_to_fill = build_forwards_coords(x1, y1, x2, y2)
     end
 
-    print coords_to_fill
-    puts coords_to_fill.size
-    puts x1
-    puts x2
-    puts y1
-    puts y2
-
     raise DiagonalError.new unless is_a_diagonal?(coords_to_fill, x1, x2)
 
     coords_to_fill.each do |coord|
@@ -102,13 +95,13 @@ class Bitmap
   private
 
   def is_a_diagonal?(coords, x1, x2)
-    # This is far from perfect.
+    # This is far from perfect - will fail on other test cases.
     return false if coords.size == 1
 
     # Return false if x +- 1 && y += 1 - i.e. no adjacency to the next coord.
     coords.each_index do |i|
       break if coords[i+1].nil?
-      puts false if (coords[i+1][0]) != ((coords[i][0] + 1) || (coords[i][0] - 1)) && (coords[i+1][1]) != ((coords[i][1] + 1) || (coords[i][1] - 1))
+      return false if (coords[i+1][0]) != ((coords[i][0] + 1) || (coords[i][0] - 1)) && (coords[i+1][1]) != ((coords[i][1] + 1) || (coords[i][1] - 1))
     end
     true
   end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -44,6 +44,12 @@ class InvalidColorError < StandardError
   end
 end
 
+class DiagonalError < StandardError
+  def initialize
+    super("These coords are not a valid diagonal.")
+  end
+end
+
 class ArgumentError < StandardError
   def initialize
     super("There seems to be an issue with the arguments you passed to this command. Try using ? to pull up the Help prompt")

--- a/lib/executor.rb
+++ b/lib/executor.rb
@@ -13,7 +13,8 @@ class Executor
     S: "show",
     L: "color_pixel",
     V: "vertical_segment",
-    H: "horizontal_segment"
+    H: "horizontal_segment",
+    D: "diagonal_segment"
   }
 
   attr_reader :bitmap

--- a/lib/prompt.rb
+++ b/lib/prompt.rb
@@ -1,4 +1,6 @@
-# +Interface+ provides the interface to handle user input.
+# +Prompt+ prompts the user for input and handles
+# basic feedback relating to Help and Exiting.
+# Commands that manipulate a Bitmap are handled by the +Executor+
 
 require './lib/base'
 

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -146,13 +146,36 @@ RSpec.describe Bitmap do
     # (x1, y1, x2, y2, color)
     describe "diagonal_segment" do
       before do
-        subject.horizontal_segment(1, 1,  6, 6, "A")
+        subject.clear
+        subject.diagonal_segment(1, 1,  5, 5, "A")
       end
 
-      it "colors the expected diaglonal segment" do
-        0.upto(5).each do |i|
+      it "colors the expected diagonal segment" do
+        0.upto(4).each do |i|
           expect(subject.grid[i][i]).to eq "A"
         end
+      end
+
+      # build_coords(x1, y1, x2, y2)
+      it "colors the expect diagonal segment (2nd test)" do
+        subject.clear
+        subject.diagonal_segment(2, 1,  5, 4, "A")
+
+        #print subject.grid
+        expect(subject.grid[0][1]).to eq "A"
+        expect(subject.grid[1][2]).to eq "A"
+        expect(subject.grid[2][3]).to eq "A"
+        expect(subject.grid[3][4]).to eq "A"
+      end
+
+      it "accepts negative coords" do
+        subject.clear
+        subject.diagonal_segment(3, 3,  1, 1, "A")
+
+        print subject.grid
+        expect(subject.grid[0][0]).to eq "A"
+        expect(subject.grid[1][1]).to eq "A"
+        expect(subject.grid[2][2]).to eq "A"
       end
     end
 

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -142,46 +142,51 @@ RSpec.describe Bitmap do
       end
       expect(subject.grid[0][4]).to eq "O"
     end
+  end
 
-    # (x1, y1, x2, y2, color)
-    describe "diagonal_segment" do
-      before do
-        subject.clear
-        subject.diagonal_segment(1, 1,  5, 5, "A")
-      end
+  # (x1, y1, x2, y2, color)
+  describe "diagonal_segment" do
+    before do
+      subject.clear
+      subject.diagonal_segment(1, 1, 5, 5, "A")
+    end
 
-      it "colors the expected diagonal segment" do
-        0.upto(4).each do |i|
-          expect(subject.grid[i][i]).to eq "A"
-        end
-      end
-
-      # build_coords(x1, y1, x2, y2)
-      it "colors the expect diagonal segment (2nd test)" do
-        subject.clear
-        subject.diagonal_segment(2, 1,  5, 4, "A")
-
-        #print subject.grid
-        expect(subject.grid[0][1]).to eq "A"
-        expect(subject.grid[1][2]).to eq "A"
-        expect(subject.grid[2][3]).to eq "A"
-        expect(subject.grid[3][4]).to eq "A"
-      end
-
-      it "accepts negative coords" do
-        subject.clear
-        subject.diagonal_segment(3, 3,  1, 1, "A")
-
-        print subject.grid
-        expect(subject.grid[0][0]).to eq "A"
-        expect(subject.grid[1][1]).to eq "A"
-        expect(subject.grid[2][2]).to eq "A"
+    it "colors the expected diagonal segment" do
+      0.upto(4).each do |i|
+        expect(subject.grid[i][i]).to eq "A"
       end
     end
 
-    it "raises an error if the color is not A-Z" do
-      message = "1 is not a valid color - must be a capital letter A-Z"
-      expect { subject.vertical_segment(100, 1, 2, 1) }.to raise_error (message)
+    it "colors the expect diagonal segment (2nd test)" do
+      subject.clear
+      subject.diagonal_segment(2, 1, 5, 4, "A")
+
+      expect(subject.grid[0][1]).to eq "A"
+      expect(subject.grid[1][2]).to eq "A"
+      expect(subject.grid[2][3]).to eq "A"
+      expect(subject.grid[3][4]).to eq "A"
     end
+
+    it "draws the line on the backwards diagonal" do
+      subject.clear
+      subject.diagonal_segment(1, 5, 5, 1, "A")
+
+      print "\n"
+      0.upto(subject.grid.size) do |i|
+        print subject.grid[i]
+        print "\n"
+      end
+
+      expect(subject.grid[0][4]).to eq "A"
+      expect(subject.grid[1][3]).to eq "A"
+      expect(subject.grid[2][2]).to eq "A"
+      expect(subject.grid[3][1]).to eq "A"
+      expect(subject.grid[4][0]).to eq "A"
+    end
+  end
+
+  it "raises an error if the color is not A-Z" do
+    message = "1 is not a valid color - must be a capital letter A-Z"
+    expect { subject.vertical_segment(100, 1, 2, 1) }.to raise_error (message)
   end
 end

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -171,17 +171,32 @@ RSpec.describe Bitmap do
       subject.clear
       subject.diagonal_segment(1, 5, 5, 1, "A")
 
-      print "\n"
-      0.upto(subject.grid.size) do |i|
-        print subject.grid[i]
-        print "\n"
-      end
+      # print "\n"
+      # 0.upto(subject.grid.size) do |i|
+      #   print subject.grid[i]
+      #   print "\n"
+      # end
 
       expect(subject.grid[0][4]).to eq "A"
       expect(subject.grid[1][3]).to eq "A"
       expect(subject.grid[2][2]).to eq "A"
       expect(subject.grid[3][1]).to eq "A"
       expect(subject.grid[4][0]).to eq "A"
+    end
+
+    it "raises" do
+      message = "These coords are not a valid diagonal."
+      expect { subject.diagonal_segment(5, 5, 5, 5, "A") }.to raise_error (message)
+    end
+
+    it "raises an error if any of the specified pixels are out of bounds" do
+      message = "One or more of the pixels in this segment are out of bounds"
+      expect { subject.diagonal_segment(1, 6, 6, 1, "A") }.to raise_error (message)
+    end
+
+    it "raises an error if the color is not A-Z" do
+      message = "x is not a valid color - must be a capital letter A-Z"
+      expect { subject.diagonal_segment(1, 5, 5, 1, "x") }.to raise_error (message)
     end
   end
 

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -171,22 +171,11 @@ RSpec.describe Bitmap do
       subject.clear
       subject.diagonal_segment(1, 5, 5, 1, "A")
 
-      # print "\n"
-      # 0.upto(subject.grid.size) do |i|
-      #   print subject.grid[i]
-      #   print "\n"
-      # end
-
       expect(subject.grid[0][4]).to eq "A"
       expect(subject.grid[1][3]).to eq "A"
       expect(subject.grid[2][2]).to eq "A"
       expect(subject.grid[3][1]).to eq "A"
       expect(subject.grid[4][0]).to eq "A"
-    end
-
-    it "raises" do
-      message = "These coords are not a valid diagonal."
-      expect { subject.diagonal_segment(5, 5, 5, 5, "A") }.to raise_error (message)
     end
 
     it "raises an error if any of the specified pixels are out of bounds" do

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -189,6 +189,11 @@ RSpec.describe Bitmap do
     end
   end
 
+  it "raises DiagonalError is the coords do not allow a valid diagonal" do
+    message = "These coords are not a valid diagonal."
+    expect { subject.diagonal_segment(5, 5, 5, 5, "A") }.to raise_error (message)
+  end
+
   it "raises an error if the color is not A-Z" do
     message = "1 is not a valid color - must be a capital letter A-Z"
     expect { subject.vertical_segment(100, 1, 2, 1) }.to raise_error (message)

--- a/spec/bitmap_spec.rb
+++ b/spec/bitmap_spec.rb
@@ -143,6 +143,19 @@ RSpec.describe Bitmap do
       expect(subject.grid[0][4]).to eq "O"
     end
 
+    # (x1, y1, x2, y2, color)
+    describe "diagonal_segment" do
+      before do
+        subject.horizontal_segment(1, 1,  6, 6, "A")
+      end
+
+      it "colors the expected diaglonal segment" do
+        0.upto(5).each do |i|
+          expect(subject.grid[i][i]).to eq "A"
+        end
+      end
+    end
+
     it "raises an error if the color is not A-Z" do
       message = "1 is not a valid color - must be a capital letter A-Z"
       expect { subject.vertical_segment(100, 1, 2, 1) }.to raise_error (message)

--- a/spec/executor_spec.rb
+++ b/spec/executor_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Executor do
         subject.execute("L 1 1 A")
       end
 
-      it "paints a horizontal line (x1, x2, y, color)" do
+      it "paints a horizontal segment (x1, x2, y, color)" do
         expect(bitmap).to receive(:horizontal_segment).with("1", "6", "4", "A")
         subject.execute("H 1 6 4 A")
       end
 
-      it "paints a vertical line (x, y1, y2, color)" do
+      it "paints a vertical segment(x, y1, y2, color)" do
         expect(bitmap).to receive(:vertical_segment).with("1", "1", "4", "X")
         subject.execute("V 1 1 4 X")
       end
@@ -42,6 +42,11 @@ RSpec.describe Executor do
       it "shows the bitmap" do
         expect(bitmap).to receive(:show)
         subject.execute("S")
+      end
+
+      it "paint a diagonal segment" do
+        expect(bitmap).to receive(:diagonal_segment).with("1", "5", "5", "1", "X")
+        subject.execute("D 1 5 5 1 X")
       end
     end
 


### PR DESCRIPTION
Opens a PR to add a new diagonal segment feature. Instructions for testing:

`ruby runner.rb
I 5 5
D 1 5 5 1 A
S
`
Check that the output resembles the following:

```
["O", "O", "O", "O", "A"]
["O", "O", "O", "A", "O"]
["O", "O", "A", "O", "O"]
["O", "A", "O", "O", "O"]
["A", "O", "O", "O", "O"]
```

Improvements/work still to be done on this branch.
- Do not accept Coords that are not a valid diagonal (e.g. 1, 1 to 4, 2).
- Accept coords where X1 is larger than X2 through a simple swap `x1, x2 = x2, x1` (at present we do not accept this). e.g. (D 5 1 1 5 S). This will provide greater user flexibility.
